### PR TITLE
Dependencies updated in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dependencies
 This is a Python 3.6 package. Required packages can be installed with e.g. `pip` and `conda`:
 ```
 > conda create -n c3dpo python=3.6
-> pip install -r requirements.txt
+> pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 The complete list of dependencies:


### PR DESCRIPTION

![c3dpo_nrsfm_readme_ss](https://user-images.githubusercontent.com/26977596/99886378-06f3f300-2c62-11eb-9ef8-5f4ca8f9b8d8.png)

While installing Dependencies from requirements.txt 
throwing Error 
![c3dpo_nrsfm_error_ss](https://user-images.githubusercontent.com/26977596/99885875-048f9a00-2c5e-11eb-868e-f5ede7b50aeb.png)
So after some searching, I get to know that
in order to install torch==1.1.0 we have to specifically provide "-f https://download.pytorch.org/whl/torch_stable.html" with pip command otherwise it throws errors because by default pip search for a package in https://pypi.org/simple only and torch 1.1.0 isn't available there that's why we give source URL for torch 1.1.0 separately( https://download.pytorch.org/whl/torch_stable.html ).
So I added it in requirements.txt 
![c3dpo_nrsfm_requir_txt_error_ss](https://user-images.githubusercontent.com/26977596/99886113-065a5d00-2c60-11eb-9d7c-05ce3b638c0d.png)
although it doesn't work.
![c3dpo_nrsfm_second_error_ss](https://user-images.githubusercontent.com/26977596/99886178-900a2a80-2c60-11eb-9c24-8f6e2465442a.png)
and after searching and trial&error i got this way working perfectly in installation.
"pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html"
So I decided to update it in README.md file to save other people's time to eliminating errors in the installation.
Thank you

