### PR TITLE
Dependencies updated in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dependencies
 This is a Python 3.6 package. Required packages can be installed with e.g. `pip` and `conda`:
 ```
 > conda create -n c3dpo python=3.6
-> pip install -r requirements.txt
+> pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 The complete list of dependencies:


### PR DESCRIPTION

![c3dpo_nrsfm_readme_ss](https://user-images.githubusercontent.com/26977596/99898529-efe7ec00-2cc7-11eb-8fae-763806883946.png)

While installing Dependencies from requirements.txt
throwing Error
![c3dpo_nrsfm_error_ss](https://user-images.githubusercontent.com/26977596/99898541-ffffcb80-2cc7-11eb-863a-31e975f26132.png)

So after some searching, I get to know that
in order to install torch==1.1.0 we have to specifically provide "-f https://download.pytorch.org/whl/torch_stable.html" with pip command otherwise it throws errors because by default pip search for a package in https://pypi.org/simple only and torch 1.1.0 isn't available there that's why we give source URL for torch 1.1.0 separately( https://download.pytorch.org/whl/torch_stable.html ).
So I added it in requirements.txt
![c3dpo_nrsfm_requir_txt_error_ss](https://user-images.githubusercontent.com/26977596/99898546-0f7f1480-2cc8-11eb-8fc9-df205d239e06.png)

although it doesn't work.
![c3dpo_nrsfm_second_error_ss](https://user-images.githubusercontent.com/26977596/99898549-160d8c00-2cc8-11eb-901f-dd71d83b24c9.png)

and after searching and trial&error i got this way working perfectly in installation.
"pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html"
So I decided to update it in README.md file to save other people's time to eliminating errors in the installation.
Thank you